### PR TITLE
Have wazuh install script (for AL2023) also install `rsyslog`

### DIFF
--- a/deploy-wazuh-amzn2023-docker-host
+++ b/deploy-wazuh-amzn2023-docker-host
@@ -105,10 +105,13 @@ yum -y remove python3-requests
 yum -y install python3-pip
 /usr/bin/pip3 install docker urllib3 requests
 
-# Install cron (cronie) which is no included by default in Amazon Linux 2023
-yum install cronie -y
+# Install cron (cronie) and rsyslog, which are no included by default in Amazon Linux 2023
+yum -y install cronie 
 systemctl enable crond.service
 systemctl start crond.service
+yum -t install rsyslog 
+systemctl enable rsyslog.service
+systemctl start rsyslog.service
 
 # Set up daily log flushing via cron
 echo -e '#!/bin/bash\nsystemctl stop wazuh-agent; rm -rf /var/ossec/logs/*; systemctl start wazuh-agent' > /etc/cron.daily/flush-logs

--- a/deploy-wazuh-amzn2023-docker-host
+++ b/deploy-wazuh-amzn2023-docker-host
@@ -109,7 +109,7 @@ yum -y install python3-pip
 yum -y install cronie 
 systemctl enable crond.service
 systemctl start crond.service
-yum -t install rsyslog 
+yum -y install rsyslog 
 systemctl enable rsyslog.service
 systemctl start rsyslog.service
 


### PR DESCRIPTION
### Added
- Added install of rsyslog which is also not present in Amazon Linux 2023, in order to attempt to get the common Linux log streams as well.

---

**Note:**
These changes are from the parent repo of this fork.