### PR TITLE
Remove outdated python3-requests removal command

### DIFF
--- a/deploy-wazuh-amzn2023-docker-host
+++ b/deploy-wazuh-amzn2023-docker-host
@@ -98,9 +98,6 @@ O7bM4haWNBQkxEU=
 " > /var/ossec/etc/bnc_wpk_root.pem
 chown root:wazuh /var/ossec/etc/bnc_wpk_root.pem
 
-# Amazon Linux has an outdated rpm version of python3-requests which prevents a pip install of the latest.  Remove it
-yum -y remove python3-requests
-
 # Meet Wazuh docker listener prereqs in a Python virtual environment and adjust the main script to operate from it.
 yum -y install python3-pip
 mkdir /venv


### PR DESCRIPTION
[ITSE-1399](https://support.gtis.sil.org/issue/ITSE-1399) Add Wazuh agent to our IDPs (like Wycliffe USA has done for theirs)

---

### Fixed
- Remove outdated python3-requests removal command
  * The Python virtual environment code had been added, but the code to delete python3-requests had not been removed. This fixes that.